### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/source/cf/sputnik-lambda-helpers.yml
+++ b/source/cf/sputnik-lambda-helpers.yml
@@ -150,7 +150,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-custom-resource-helper-s3.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt customResourcesIAMRole.Arn
             Timeout: 300
             MemorySize: 256
@@ -164,7 +164,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-custom-resource-helper-utils.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt customResourcesIAMRole.Arn
             Timeout: 300
             MemorySize: 256

--- a/source/cf/sputnik-lambda-services.yml
+++ b/source/cf/sputnik-lambda-services.yml
@@ -117,7 +117,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-admin-service.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt adminServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256
@@ -198,7 +198,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-deployments-service.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt deploymentsServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256
@@ -281,7 +281,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-devices-service.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt devicesServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256
@@ -353,7 +353,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ["/", [!Ref sourceKeyPrefix, 'lambda', "sputnik-settings-service.zip"]]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt settingsServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256
@@ -429,7 +429,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ['/', [!Ref sourceKeyPrefix, 'lambda', 'sputnik-systems-service.zip']]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt systemsServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256
@@ -527,7 +527,7 @@ Resources:
                 S3Bucket: !Ref sourceBucket
                 S3Key: !Join ["/", [!Ref sourceKeyPrefix, 'lambda', "sputnik-just-in-time-on-boarding-service.zip"]]
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt justInTimeOnBoardingServiceLambdaFunctionIAMRole.Arn
             Timeout: 60
             MemorySize: 256


### PR DESCRIPTION
CloudFormation templates in aws-iot-kickstart have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.