### PR TITLE
Fix lambda layers parameter naming to be unique for stack

### DIFF
--- a/configs/workspace/tsconfig.json
+++ b/configs/workspace/tsconfig.json
@@ -18,6 +18,10 @@
     "rootDir": "../../",
     "baseUrl": ".",
     "lib": ["dom", "esnext"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../@types",
+    ]
   },
   "include": ["jest-dom/extend-expect"]
 }

--- a/packages/infra/sputnik-infra-core/src/utils/cdk-identity-utils.ts
+++ b/packages/infra/sputnik-infra-core/src/utils/cdk-identity-utils.ts
@@ -1,7 +1,8 @@
+import { unique as shorthash } from 'shorthash'
 import { CfnResource, CfnStack, Construct, Resource, Stack, NestedStack } from '@aws-cdk/core'
 
 export function uniqueIdHash (construct: Construct): string {
-	return construct.node.uniqueId.substr(-8)
+	return shorthash(construct.node.uniqueId)
 }
 
 export function overrideLogicalId (resource: Resource | CfnResource | CfnStack | NestedStack, logicalId: string): void {

--- a/packages/infra/sputnik-infra-core/tsconfig.json
+++ b/packages/infra/sputnik-infra-core/tsconfig.json
@@ -12,5 +12,8 @@
   },
   "compileOnSave": true,
   "exclude": ["node_modules", "lib"],
-  "include": ["src"]
+  "include": ["src"],
+  "files": [
+    "../../../@types/shorthash.d.ts"
+  ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prevent the following CloudFormation deployment error
```
/shared-layer-version-proxy/sputnik-lib/shared/layerVersionArn already exists in stack arn:aws:cloudformation:ap-southeast-1:118513466446:stack/DevProto-SputnikPeristent/72d64960-d45b-11ea-a1cb-0a2bfeee7532
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
